### PR TITLE
Move React to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,15 @@
   "dependencies": {
     "get-youtube-id": "^0.1.3",
     "random-global": "^1.0.0",
-    "react": "^0.12.1",
     "require-sdk": "0.0.2"
   },
   "devDependencies": {
     "autoprefixer": "^4.0.0",
     "browserify": "^6.2.0",
     "jest-cli": "^0.1.18"
+  },
+  "peerDependencies": {
+    "react": "^0.12.1"
   },
   "jest": {
     "unmockedModulePathPatterns": [


### PR DESCRIPTION
It's incorrect to put React in dependencies because this causes duplicate React installation in `react-youtube/node_modules` when doing `npm install`.