### PR TITLE
Added isomorphic rendering support

### DIFF
--- a/src/lib/createPlayer.js
+++ b/src/lib/createPlayer.js
@@ -4,7 +4,6 @@
 
 import assign from 'object-assign';
 import getYouTubeId from 'get-youtube-id';
-import YouTubeIframeLoader from 'youtube-iframe';
 
 /**
  * Create a new `player` by requesting and using the YouTube Iframe API
@@ -18,6 +17,8 @@ import YouTubeIframeLoader from 'youtube-iframe';
  */
 
 const createPlayer = (containerId, props, cb) => {
+  let YouTubeIframeLoader = require('youtube-iframe');
+
   const params = assign({}, props.opts, {
     videoId: getYouTubeId(props.url)
   });

--- a/src/lib/createPlayer.js
+++ b/src/lib/createPlayer.js
@@ -17,7 +17,7 @@ import getYouTubeId from 'get-youtube-id';
  */
 
 const createPlayer = (containerId, props, cb) => {
-  let YouTubeIframeLoader = require('youtube-iframe');
+  const YouTubeIframeLoader = require('youtube-iframe');
 
   const params = assign({}, props.opts, {
     videoId: getYouTubeId(props.url)


### PR DESCRIPTION
This PR moves the `require` call inside the `createPlayer` method. This allows `react-youtube` to effectively be isomorphic and render on the server-side. Currently, my server instance dies as soon as it tries to import `youtube-iframe`, which is meant for the client-side. This PR puts the `require` where it will only be called on the client-side.