### PR TITLE
Only destroy the youtube player if it is initialized

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -99,7 +99,7 @@ class YouTube extends React.Component {
   }
 
   onReset() {
-    if (this._internalPlayer) {
+    if (this._internalPlayer && this._internalPlayer.getIframe()) {
       this._internalPlayer.removeEventListener('onReady', this._playerReadyHandle);
       this._internalPlayer.removeEventListener('onError', this._playerErrorHandle);
       this._internalPlayer.removeEventListener('onStateChange', this._stateChangeHandle);


### PR DESCRIPTION
If you are very quickly creating and destroying YouTube components, the iframe might not be initialized by the time we want to destroy it, resulting in this error: `Uncaught TypeError: this._internalPlayer.removeEventListener is not a function`.

This doesn't seem perfect, but I couldn't think of a better check.