### PR TITLE
Check for removeEventListener before calling it.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-youtube",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "react.js powered YouTube player component",
   "main": "dist/YouTube.js",
   "repository": {

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -99,7 +99,7 @@ class YouTube extends React.Component {
   }
 
   onReset() {
-    if (this._internalPlayer && this._internalPlayer.getIframe()) {
+    if (this._internalPlayer && typeof this._internalPlayer.removeEventListener === 'function') {
       this._internalPlayer.removeEventListener('onReady', this._playerReadyHandle);
       this._internalPlayer.removeEventListener('onError', this._playerErrorHandle);
       this._internalPlayer.removeEventListener('onStateChange', this._stateChangeHandle);


### PR DESCRIPTION
Sometimes the iframe exists, but the player doesn't have `removeEventListener` on it yet.

retrying solving #30