### PR TITLE
Modified onReset() to properly destroy internal player

### DIFF
--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -103,13 +103,14 @@ class YouTube extends React.Component {
       this._internalPlayer.removeEventListener('onReady', this._playerReadyHandle);
       this._internalPlayer.removeEventListener('onError', this._playerErrorHandle);
       this._internalPlayer.removeEventListener('onStateChange', this._stateChangeHandle);
-
-      this._internalPlayer.destroy();
-
-      delete this._playerReadyHandle;
-      delete this._playerErrorHandle;
-      delete this._stateChangeHandle;
     }
+    if (this._internalPlayer) {
+      this._internalPlayer.destroy();
+    }
+
+    delete this._playerReadyHandle;
+    delete this._playerErrorHandle;
+    delete this._stateChangeHandle;
   }
 
   /**


### PR DESCRIPTION
In my experiments with this excellent component, I noticed a bug that is fixed by modifying the `onReset()` function to call `destroy()` on `this._internalPlayer` regardless of existence of `this._internalPlayer.removeEventListener()`.

This bug manifests itself when the url prop is modified quickly, which for some reason causes the reset procedure to break. Once this happens, the video is never changed again, until component was unmounted and remounted.