### PR TITLE
added this.props.onStateChange to allow finer control about events

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Usage
   onPause={func}          // defaults -> noop
   onEnd={func}            // defaults -> noop
   onError={func}          // defaults -> noop
+  onStateChange={func}    // defaults -> noop
 />
 ```
 

--- a/src/YouTube.js
+++ b/src/YouTube.js
@@ -31,6 +31,7 @@ class YouTube extends React.Component {
     onPlay: React.PropTypes.func,
     onPause: React.PropTypes.func,
     onEnd: React.PropTypes.func,
+    onStateChange: React.PropTypes.func,
   };
 
   static defaultProps = {
@@ -40,6 +41,7 @@ class YouTube extends React.Component {
     onPlay: () => {},
     onPause: () => {},
     onEnd: () => {},
+    onStateChange: () => {},
   };
 
   /**
@@ -144,6 +146,8 @@ class YouTube extends React.Component {
    */
 
   onPlayerStateChange(event) {
+    this.props.onStateChange(event);
+    
     switch (event.data) {
 
     case window.YT.PlayerState.ENDED:


### PR DESCRIPTION
Hi! Thank you for react-youtube, it really saved my life in a project I'm working on.

But: I need a finer control about the changing state of the player. So I added the optional onStateChange prop, that will also take a function. It shouldn't break the plugin for anyone else, but would make it work for me.

(The previous pull request had an error in it: The onStateChange-Function wasn't called on every event)

Regards,
Daniel